### PR TITLE
Cache binaries for future builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ variable](https://devcenter.heroku.com/articles/config-vars). For example:
 
 The buildpack will install the latest libvips if the value of `LIBVIPS_VERSION` is
 `latest` or the variable is omitted.
+
+The first time you deploy, libvips will be compiled during deployment, adding
+minutes to the deployment time. The installation will be cached, so subsequent
+deploys will not recompile unless the libvips version changes.

--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,7 @@
 set -euo pipefail
 
 BUILD_DIR=$1
+CACHE_DIR="$2/libvips"
 ENV_DIR=$3
 TMP_DIR="$BUILD_DIR/.libvips-tmp"
 BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
@@ -15,5 +16,6 @@ VIPS_PATH="$VENDOR_PATH/vips"
 source "$BP_DIR/bin/buildscript.sh"
 
 ensure_dirs
-build_libvips && cleanup_build
+install_libvips
+cleanup_build
 export_profile


### PR DESCRIPTION
Addresses #1.

Caches the results of compilation in a directory specific to the version. When the cached version doesn't match the specified version, the cache is destroyed before compiling the new version. This happens so the cache directory doesn't fill up with old versions.

Bash is not one of my skills, so please review thoroughly and let me know if anything needs to be changed.